### PR TITLE
Added --bare option

### DIFF
--- a/lib/coffeeCoverage.js
+++ b/lib/coffeeCoverage.js
@@ -43,7 +43,8 @@
   defaultOptions = {
     coverageVar: '_$jscoverage',
     exclude: [],
-    recursive: true
+    recursive: true,
+    bare: false
   };
 
   exports.CoverageInstrumentor = (function(_super) {
@@ -270,7 +271,9 @@
         init += toQuotedString(line);
       }
       init += "];\n\n";
-      js = ast.compile({});
+      js = ast.compile({
+        bare: options.bare
+      });
       return {
         init: init,
         js: js,

--- a/lib/command.js
+++ b/lib/command.js
@@ -28,6 +28,11 @@
       help: "Verbose output",
       nargs: 0
     });
+    parser.addArgument(['-b', '--bare'], {
+      help: "compile without a top-level function wrapper",
+      metavar: "bare",
+      nargs: 0
+    });
     coverageVarDefault = '_$jscoverage';
     parser.addArgument(['-c', '--coverageVar'], {
       help: "Set the name to use in the instrumented code for the coverage variable.  Defaults to\n'" + coverageVarDefault + "'.",
@@ -69,7 +74,12 @@
     var coverageInstrumentor, options, result, _ref1;
     try {
       options = parseArgs(args.slice(2));
-      coverageInstrumentor = new CoverageInstrumentor();
+      if (options.bare) {
+        options.bare = true;
+      }
+      coverageInstrumentor = new CoverageInstrumentor({
+        bare: options.bare
+      });
       if (options.verbose) {
         coverageInstrumentor.on("instrumentingFile", function(sourceFile, outFile) {
           return console.log("    " + (stripLeadingDot(sourceFile)) + " to " + (stripLeadingDot(outFile)));

--- a/src/coffeeCoverage.coffee
+++ b/src/coffeeCoverage.coffee
@@ -34,6 +34,7 @@ defaultOptions =
     coverageVar: '_$jscoverage'
     exclude: []
     recursive: true
+    bare: false
 
 #### CoverageInstrumentor
 #
@@ -348,7 +349,7 @@ class exports.CoverageInstrumentor extends events.EventEmitter
         init += "];\n\n"
 
         # Compile the instrumented CoffeeScript and write it to the JS file.
-        js = ast.compile {}
+        js = ast.compile {bare: options.bare}
 
         return {
             init: init

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -25,6 +25,11 @@ parseArgs = (args) ->
         help: "Verbose output"
         nargs: 0
 
+    parser.addArgument [ '-b', '--bare' ],
+        help: "compile without a top-level function wrapper"
+        metavar: "bare"
+        nargs: 0
+
     coverageVarDefault = '_$jscoverage'
     parser.addArgument [ '-c', '--coverageVar' ],
         help: """Set the name to use in the instrumented code for the coverage variable.  Defaults to
@@ -76,7 +81,10 @@ exports.main = (args) ->
     try
         options = parseArgs(args[2..])
 
-        coverageInstrumentor = new CoverageInstrumentor()
+        if options.bare
+            options.bare = true
+
+        coverageInstrumentor = new CoverageInstrumentor(bare: options.bare)
 
         if options.verbose
             coverageInstrumentor.on "instrumentingFile", (sourceFile, outFile) ->


### PR DESCRIPTION
Added the --bare option for the coffeescript compiler, so files can be instrumented without being wrapped in a top level function wrapper. Same as calling coffee --bare.
