### PR TITLE
add literate CoffeeScript support

### DIFF
--- a/lib/coffeeCoverage.js
+++ b/lib/coffeeCoverage.js
@@ -27,6 +27,12 @@
     ".coffee": {
       js_extension: ".js"
     },
+    ".litcoffee": {
+      js_extension: ".js"
+    },
+    ".coffee.md": {
+      js_extension: ".js"
+    },
     "._coffee": {
       js_extension: "._js"
     }
@@ -76,7 +82,7 @@
   };
 
   exports.register = function(options) {
-    var basePath, coverage, excludeFile, initStream, instrumentFile, module, origCoffeeHandler, origStreamineCoffeeHandler, streamline_js;
+    var basePath, coverage, excludeFile, initStream, instrumentFile, module, origStreamineCoffeeHandler, replaceHandler, streamline_js;
     coverage = new exports.CoverageInstrumentor(options);
     module = require('module');
     if (options.basePath) {
@@ -119,13 +125,19 @@
       instrumented = coverage.instrumentCoffee(coverageFileName, content, options);
       return instrumented.init + instrumented.js;
     };
-    origCoffeeHandler = require.extensions[".coffee"];
-    require.extensions[".coffee"] = function(module, fileName) {
-      if (excludeFile(fileName)) {
-        return origCoffeeHandler.call(this, module, fileName);
-      }
-      return module._compile(instrumentFile(fileName), fileName);
+    replaceHandler = function(extension) {
+      var origCoffeeHandler;
+      origCoffeeHandler = require.extensions[extension];
+      return require.extensions[extension] = function(module, fileName) {
+        if (excludeFile(fileName)) {
+          return origCoffeeHandler.call(this, module, fileName);
+        }
+        return module._compile(instrumentFile(fileName), fileName);
+      };
     };
+    replaceHandler(".coffee");
+    replaceHandler(".litcoffee");
+    replaceHandler(".coffee.md");
     if (options.streamlinejs) {
       streamline_js = require.extensions["._js"];
       if (streamline_js) {
@@ -346,12 +358,13 @@
     };
 
     CoverageInstrumentor.prototype.instrumentCoffee = function(fileName, fileData, options) {
-      var answer, ast, err, fileToInstrumentLines, index, init, instrumentTree, instrumentedLines, js, line, lineNumber, origFileName, quotedFileName, _i, _j, _len, _len1, _ref1,
+      var answer, ast, err, fileToInstrumentLines, index, init, instrumentTree, instrumentedLines, js, line, lineNumber, literate, origFileName, quotedFileName, _i, _j, _len, _len1, _ref1,
         _this = this;
       if (options == null) {
         options = {};
       }
       origFileName = fileName;
+      literate = /\.(litcoffee|coffee\.md)$/.test(fileName);
       switch (options.path) {
         case 'relative':
           fileName = stripLeadingDotOrSlash(fileName);
@@ -370,7 +383,9 @@
       }
       quotedFileName = toQuotedString(fileName);
       try {
-        ast = coffeeScript.nodes(fileData);
+        ast = coffeeScript.nodes(fileData, {
+          literate: literate
+        });
       } catch (_error) {
         err = _error;
         throw new CoverageError("Could not parse " + fileName + ": " + err.stack);
@@ -441,7 +456,8 @@
       init += "];\n\n";
       try {
         js = ast.compile({
-          bare: options.bare
+          bare: options.bare,
+          literate: literate
         });
       } catch (_error) {
         err = _error;


### PR DESCRIPTION
Implements #4.

Grab this version for testing (not production) via `package.json`:

``` json
"dependencies": {
  "coffee-coverage": "https://api.github.com/repos/frozenice-/coffee-coverage/tarball"
}
```
