### PR TITLE
Exposing options.basepath as a command-line flag

### DIFF
--- a/src/coffeeCoverage.coffee
+++ b/src/coffeeCoverage.coffee
@@ -48,12 +48,12 @@ defaultOptions =
     recursive: true
     bare: false
 
-# Return the relative path for the file from the basePath.  Returns file name
-# if the file is not relative to basePath.
-getRelativeFilename = (basePath, fileName) ->
+# Return the relative path for the file from the basepath.  Returns file name
+# if the file is not relative to basepath.
+getRelativeFilename = (basepath, fileName) ->
     relativeFileName = path.resolve fileName
-    if basePath? and startsWith(relativeFileName, basePath)
-        relativeFileName = path.relative basePath, fileName
+    if basepath? and startsWith(relativeFileName, basepath)
+        relativeFileName = path.relative basepath, fileName
     return relativeFileName
 
 
@@ -67,7 +67,7 @@ getRelativeFilename = (basePath, fileName) ->
 # Parameters:
 # * `options.coverageVar` gives the name of the global variable to use to store coverage data in.
 #   This defaults to '_$jscoverage' to be compatible with JSCoverage.
-# * `options.basePath` is the root folder of your project.  This path will be stripped from
+# * `options.basepath` is the root folder of your project.  This path will be stripped from
 #   file names.
 # * `options.path` should be one of:
 #     * 'relative' - File names will be used as the file name in the instrumented sources.
@@ -77,27 +77,27 @@ getRelativeFilename = (basePath, fileName) ->
 # * `options.exclude` is an array of files to ignore.  instrumentDirectory will not instrument
 #   a file if it is in this list, nor will it recursively traverse into a directory if it is
 #   in this list.  This defaults to [] if not explicitly passed.  Note that this option
-#   will only work if `options.basePath` is provided.
+#   will only work if `options.basepath` is provided.
 # * `options.streamlinejs` - Enable experimental support for streamlinejs.  This option will
 #   be removed in a future version of coffeeCoverage.
 # * `options.initAll` - If true, then coffeeCoverage will recursively walk through all
-#   subdirectories of `options.basePath` and gather line number information for all CoffeeScript files
+#   subdirectories of `options.basepath` and gather line number information for all CoffeeScript files
 #   found.  This way even files which are not `require`d at any point during your test will still
 #   br instrumented and reported on.
 #
-# e.g. `coffeeCoverage.register {path: 'abbr', basePath: "#{__dirname}/.." }`
+# e.g. `coffeeCoverage.register {path: 'abbr', basepath: "#{__dirname}/.." }`
 #
 exports.register = (options) ->
     coverage = new exports.CoverageInstrumentor options
     module = require('module');
 
-    if options.basePath
-        basePath = path.resolve options.basePath
+    if options.basepath
+        basepath = path.resolve options.basepath
 
         if options.initAll
             # Recursively instrument everything in the base path to generate intialization data.
             initStream = new StringStream()
-            coverage.instrumentDirectory options.basePath, null, {
+            coverage.instrumentDirectory options.basepath, null, {
                 exclude: options.exclude
                 recursive: true
                 initFileStream: initStream
@@ -109,8 +109,8 @@ exports.register = (options) ->
         exclude = options.exclude or []
 
         excluded = false
-        if basePath
-            relativeFilename = getRelativeFilename basePath, fileName
+        if basepath
+            relativeFilename = getRelativeFilename basepath, fileName
             if relativeFilename == fileName
                 # Only instrument files that are inside the project.
                 excluded = true
@@ -138,7 +138,7 @@ exports.register = (options) ->
 
     instrumentFile = (fileName) ->
         content = fs.readFileSync fileName, 'utf8'
-        coverageFileName = getRelativeFilename basePath, fileName
+        coverageFileName = getRelativeFilename basepath, fileName
         instrumented = coverage.instrumentCoffee coverageFileName, content, options
         return instrumented.init + instrumented.js
 
@@ -273,10 +273,10 @@ class exports.CoverageInstrumentor extends events.EventEmitter
     #   a file if it is in this list, nor will it recursively traverse into a directory if it is
     #   in this list.  This defaults to [] if not explicitly passed or specified in the
     #   constructor.  Note that this field is case sensitive!
-    # * `options.basePath` if provided, then all excludes will be evaluated relative to this
-    #   base path.  For example, if `options.exclude` is `['a/b']`, and `options.basePath` is
+    # * `options.basepath` if provided, then all excludes will be evaluated relative to this
+    #   base path.  For example, if `options.exclude` is `['a/b']`, and `options.basepath` is
     #   "/Users/jwalton/myproject", then this will prevent coffeeCoverage from traversing
-    #   "/Users/jwalton/myproject/a/b".  `basePath` will also be stripped from the front
+    #   "/Users/jwalton/myproject/a/b".  `basepath` will also be stripped from the front
     #   of any files when generating names.
     # * `options.initFileStream` is a stream to which all global initialization will be
     #   written to via `initFileStream.write(data)`.
@@ -299,8 +299,8 @@ class exports.CoverageInstrumentor extends events.EventEmitter
 
         options = Object.create options
         options.usedFileNames = options.usedFileNames || []
-        options.basePath = if options.basePath
-            path.resolve options.basePath
+        options.basepath = if options.basepath
+            path.resolve options.basepath
         else
             sourceDirectory
 
@@ -331,7 +331,7 @@ class exports.CoverageInstrumentor extends events.EventEmitter
                 skip = true
 
             sourceFile = sourceDirectory + file
-            relativePath = getRelativeFilename options.basePath, sourceFile
+            relativePath = getRelativeFilename options.basepath, sourceFile
             if relativePath != sourceFile then for exclude in options.exclude
                 if startsWith relativePath, exclude
                     skip = true

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -58,6 +58,10 @@ parseArgs = (args) ->
         choices: ['none', 'abbr', 'relative']
         defaultValue: "none"
 
+    parser.addArgument [ '--basepath' ],
+        help: """..."""
+        metavar: "basepath"
+
     parser.addArgument ["src"],
         help: "A file or directory to instrument.  If this is a directory, then all .coffee " +
               "files in this directory and all subdirectories will be instrumented."


### PR DESCRIPTION
**This is only a partial pull-request**. I'm not super-familiar with your codebase; no tests have been updated, and I have to admit I don't even know exactly what I'm doing.

----

My use-case: I'm instrumenting for coverage with `coffee-coverage`, then generating coverage data with `mocha-lcov-reporter`, and finally sending that information off to [Coveralls](http://coveralls.io). However, I'm running into issues, because my invocation of `coffee-coverage` is omitting the *path* to files:

    ./node_modules/.bin/coffeeCoverage --path=relative --exclude 'additional.coffee' "Source/" "Source/"

In the resulting coverage data, your instrumentation is labeling lines as something like the following:

    _$jscoverage["data.coffee"] = [];

This throws off the `coveralls` gem, as it doesn't know that your library was told only to look at files in `./Source/`, and since there's no path associated with the filename in your instrumented results, it craps itself with a file-not-existing error.

So, long story short: I have no idea why, when I call it as `coffee-coverage --path=relative`, the paths are removed from the instrumented filenames.

----

I don't quite understand your codebase, and I'm not sure what the use-case of other users or yourself may be, that the above operation is the desired one … so, instead of trying to change it to leave those paths in, I discovered I can kind of ‘hijack’ `getRelativeFilename()` to ‘fix’ my paths. I found out, accidentally, that when `options.basepath` is set to `"."`, the resolution system will leave a full (with respect to the project), but relative (with respect to the system), path to the file … which is exactly what I need!

To fix it temporarily, I've exposed that `basepath` variable as a flag on the command-line executable. Whether or not you have a preferred way of solving my problem that *isn't* this hack, that might be useful to others *anyway*; I figured it's something nice to have control over.

So: Take a look at this, and let me know if you've got an idea for a better way of solving my relative-paths issue. (=