### PR TITLE
Add coffee-coverage/register for easier mocha testing

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,0 +1,9 @@
+/**
+ * This file is useful for mocha tests
+ * To use it, run mocha --require coffee-coverage/register --reporter html-cov > coverage.html
+ */
+require('./').register({
+  basePath: process.cwd(),
+  path: 'relative',
+  exclude: ['/test', '/node_modules', '/.git'],
+});


### PR DESCRIPTION
It's kinda annoying to have to add a `coverage.js` to every project with the same code that just registers coffee-coverage for mocha tests.  By adding this file, users can get sensible defaults for coffee-coverage without needing to add a registration file to their project at all. Just install coffee-coverage and use the following command to run mocha:

    mocha --require coffee-coverage/register --reporter html-cov > coverage.html