### PR TITLE
Fix README.md#Dynamic Compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ files.  For example, create a "register-handlers.js":
         require('coffee-coverage').register({
             path: 'abbr',
             basePath: __dirname,
-            exclude: ['/test', '/node_modules', '/.git'],
+            exclude: ['test', 'node_modules', '.git'],
             initAll: true,
             streamlinejs: true
         });


### PR DESCRIPTION
According to [src/coffeeCoverage.coffee#L336](https://github.com/benbria/coffee-coverage/blob/master/src/coffeeCoverage.coffee#L336) and [src/helpers.coffee#L7](https://github.com/benbria/coffee-coverage/blob/master/src/helpers.coffee#L7), the item in exclude list must not begin with a slash.