### PR TITLE
Fix for #10

### DIFF
--- a/testFixtures/testWithLabels.coffee
+++ b/testFixtures/testWithLabels.coffee
@@ -1,0 +1,17 @@
+
+
+counter = 0
+
+`_l_1: //`
+for x in [1..10]
+    console.log x
+    if counter == 10
+        break
+    `_$l_2: //`
+    for y in [1..10]
+        console.log y
+        if y == 5 and counter < 10
+            counter++
+            `continue _l_1`
+        `continue _$l_2`
+


### PR DESCRIPTION
- fixes #10:annotation for line after label moved to before label

Still trying to figure out how to test this feature using the test fixture testWithLabels.coffee. Any ideas?

As for the labels, the inlined javascript on the coffee-script side must follow the following rule:

- single line only
- must begin with a valid javascript identifier and end with a colon plus a line comment
- production rule is as follows: ```/^[a-z_$A-Z]+[a-z_$A-Z0-9]*:\s*[/][/]\s*$/```

The instrumented javascript will look like this:

```
24 (function() {
 25   var counter, x, y, _i, _j;
 26 
 27   _$jscoverage["testWithLabels.coffee"][3]++;
 28 
 29   counter = 0;
 30 
 31   _$jscoverage["testWithLabels.coffee"][5]++;
 32 
 33   _$jscoverage["testWithLabels.coffee"][6]++;
 34 
 35   _l_1: //;
 36 
 37   for (x = _i = 1; _i <= 10; x = ++_i) {
 38     _$jscoverage["testWithLabels.coffee"][7]++;
 39     console.log(x);
 40     _$jscoverage["testWithLabels.coffee"][8]++;
 41     if (counter === 10) {
 42       _$jscoverage["testWithLabels.coffee"][9]++;
 43       break;
 44     }
 45     _$jscoverage["testWithLabels.coffee"][10]++;
 46     _$jscoverage["testWithLabels.coffee"][11]++;
 47     _$l_2: //;
 48     for (y = _j = 1; _j <= 10; y = ++_j) {
```