### PR TITLE
Fix duplicated short names

### DIFF
--- a/src/coffeeCoverage.coffee
+++ b/src/coffeeCoverage.coffee
@@ -156,7 +156,7 @@ class exports.CoverageInstrumentor extends events.EventEmitter
 
         effectiveOptions = getEffectiveOptions options, @defaultOptions
 
-        effectiveOptions.usedFileNames = effectiveOptions.usedFileNames || []
+        effectiveOptions.usedFileNameMap = effectiveOptions.usedFileNameMap || {}
         effectiveOptions.basePath = if effectiveOptions.basePath
             path.resolve effectiveOptions.basePath
         else
@@ -255,9 +255,9 @@ class exports.CoverageInstrumentor extends events.EventEmitter
     # * `options.fileName` - if rpresent, this will be the filename passed to the instrumentor.
     #   Otherwise the absolute path will be passed.
     #
-    # * If `options.usedFileNames` is present, it must be an array.  This method will add the
-    #   name of the file to usedFileNames.  If the name of the file is already in usedFileNames
-    #   then this method will generate a unique name.
+    # * If `options.usedFileNameMap` is present, it must be an object.  This method will add a
+    #   mapping from the absolute file path to the short filename in usedFileNameMap. If the name
+    #   of the file is already in usedFileNameMap then this method will generate a unique name.
     #
     # * If `options.initFileStream` is present, then all global initialization will be written
     #   to `initFileStream.write()`, in addition to being returned.

--- a/test/jsCoverageTest.coffee
+++ b/test/jsCoverageTest.coffee
@@ -103,14 +103,14 @@ describe "JSCoverage tests", ->
 
         expect(instrumentor.shortFileName).to.equal 'foo.coffee'
 
-
     it "should generate unique file names", ->
-        usedFileNames = []
+        usedFileNameMap = {}
 
         results = [
             '/foo/bar/baz/foo.coffee'
             '/foo/bar/bak/foo.coffee'
             '/foo/bar/bam/foo.coffee'
+            '/foo/bar/baz/foo.coffee'
         ].map (filename) ->
             run """
                 say "hello world"
@@ -118,7 +118,7 @@ describe "JSCoverage tests", ->
                 l: 1
                 filename,
                 coverageOptions: {
-                    usedFileNames,
+                    usedFileNameMap: usedFileNameMap,
                     basePath: '/foo',
                     path: 'abbr'
                 }
@@ -127,6 +127,7 @@ describe "JSCoverage tests", ->
         expect(results[0].instrumentor.shortFileName).to.equal 'b/b/foo.coffee'
         expect(results[1].instrumentor.shortFileName).to.equal 'b/b/foo.coffee (1)'
         expect(results[2].instrumentor.shortFileName).to.equal 'b/b/foo.coffee (2)'
+        expect(results[3].instrumentor.shortFileName).to.equal 'b/b/foo.coffee'
 
     it "should never instrument the same line twice", ->
         {instrumentor, result} = run """


### PR DESCRIPTION
This PR changes `usedFileNames` array to `usedFileNameMap`, a mapping from absolute file path to short filename. This ensures a 1-to-1 mapping even if the original filelist contains duplicates.