### PR TITLE
`postProcessors` register option

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.13",
     "mocha": "^2.1.0",
-    "sinon": "^1.14.1"
+    "sinon": "^1.14.1",
+    "streamline": "^0.12.1"
   },
   "scripts": {
     "prepublish": "npm run build && mocha",

--- a/testFixtures/streamlineFiles/bar._fake
+++ b/testFixtures/streamlineFiles/bar._fake
@@ -1,0 +1,3 @@
+exports.bar = (_) ->
+    setTimeout _, 50
+    return 5

--- a/testFixtures/streamlineFiles/foo._coffee
+++ b/testFixtures/streamlineFiles/foo._coffee
@@ -1,0 +1,3 @@
+exports.bar = (_) ->
+    setTimeout _, 50
+    return 5


### PR DESCRIPTION
This is to help mitigate the issue, and possible future issues, with `streamlinejs`'s transform api. 

In `streamlinejs` >= 1.x the location of the transform module in the project has moved, and the options have changed names completely. Instead of just updating to the new api, I thought it more prudent to make this step of the compiling a little more flexible. 

Idea: instead of hardcoding streamline in, allow the programmer to register a function that will take the compiled and instrumented `coffee` code, and apply whatever transformation process they want on it afterwards. If streamline updates again, `coffee-coverage` will not need to be updated. 

So, now, in your `register-coffee-coverage.js` loader, you could now do something like:
```javascript
var streamline = require('streamline/lib/transformSync').transform;
var coffeeCoverage = require('coffee-coverage');
// ... other stuff
coffeeCoverage.register({
    postProcessors: [
            {ext: '._coffee', fn: function(compiled, fileName) {
                var streamlineObj = streamline(compiled, {
                    filename: fileName.replace('._coffee', '._js'),
                    sourceFiles: [fileName.replace('._coffee', '._js')],
                    runtime: 'callbacks',
                    quiet: true,
                    sourceMap: 'inline'
                });
                return streamlineObj.code;
            }}
        ]
});
```

I'm not sure if this will help with anything other than `streamlinejs`. I'm up for suggestions. 
