### PR TITLE
Accept globs as excludes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,6 +62,10 @@ with:
 
     coffeeCoverage --exclude 'node_modules,.git,test' ...
 
+You can also use globs. If you have your specs next to your code you might e.g. use:
+
+    coffeeCoverage --exclude 'node_modules,.git,**/*.spec.coffee'
+
 #### --path
 
 Only used when `--inst jscoverage` is specified.  Path can be given one of three different

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "argparse": "^1.0.2",
     "coffee-script": ">=1.6.2",
     "lodash": "^3.7.0",
+    "glob": "^6.0.4",
     "pkginfo": ">=0.2.3"
   },
   "devDependencies": {

--- a/src/utils/helpers.coffee
+++ b/src/utils/helpers.coffee
@@ -3,6 +3,7 @@ fs           = require 'fs'
 path         = require 'path'
 _            = require 'lodash'
 {EXTENSIONS} = require '../constants'
+glob         = require 'glob'
 
 exports.stripLeadingDotOrSlash = (pathName) -> pathName.replace(/^\//, "").replace(/^\.\//, "")
 
@@ -63,6 +64,15 @@ exports.excludeFile = (fileName, options) ->
         if relativeFilename == fileName
             # Only instrument files that are inside the project.
             excluded = true
+
+        # For each exclude value try to use it as a pattern to exclude files
+        exclude.map (pattern) ->
+            glob.sync pattern,
+                dot: true
+                cwd: basePath
+            .forEach (file) ->
+                if relativeFilename is path.normalize file
+                    excluded = true
 
         components = relativeFilename.split path.sep
         for component in components

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -69,6 +69,23 @@ describe "Coverage tests", ->
         expect(global[COVERAGE_VAR]['a/foo.coffee'], "Should instrument a/foo.coffee").to.exist
         expect(global[COVERAGE_VAR]['b/bar.coffee'], "Should not instrument b/bar.coffee").to.not.exist
 
+    it "should exclude files based on globs when dynamically instrumenting code", ->
+
+        coffeeCoverage.register(
+            path: "relative"
+            basePath: path.resolve __dirname, '../testFixtures/testWithExcludes'
+            exclude: ["**/*r.coffee"]
+            coverageVar: COVERAGE_VAR
+            log: log
+        )
+
+        require '../testFixtures/testWithExcludes/a/foo.coffee'
+        require '../testFixtures/testWithExcludes/b/bar.coffee'
+
+        expect(global[COVERAGE_VAR], "Code should have been instrumented").to.exist
+        expect(global[COVERAGE_VAR]['a/foo.coffee'], "Should instrument a/foo.coffee").to.exist
+        expect(global[COVERAGE_VAR]['b/bar.coffee'], "Should not instrument b/bar.coffee").to.not.exist
+
     it "should handle nested recursion correctly", ->
         # From https://github.com/benbria/coffee-coverage/pull/37
         instrumentor = new coffeeCoverage.CoverageInstrumentor({


### PR DESCRIPTION
Based on #65.

BREAKING CHANGE: Excludes of directories and filenames including globbing characters (+, @, *, ?, [, ], !, {, }) will now be interpreted as globs. This shouldn't be that relevant, except for maybe + and @
