### PR TITLE
globs with leading forward slash should match relative to project root

### DIFF
--- a/src/utils/helpers.coffee
+++ b/src/utils/helpers.coffee
@@ -67,6 +67,7 @@ exports.excludeFile = (fileName, options) ->
 
         # For each exclude value try to use it as a pattern to exclude files
         exclude.map (pattern) ->
+            pattern = pattern[1..] if pattern[0] is "/"
             if minimatch relativeFilename, pattern
                 excluded = true
 

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -88,6 +88,23 @@ describe "Coverage tests", ->
         expect(global[COVERAGE_VAR][pn 'a/foo.coffee'], "Should instrument a/foo.coffee").to.exist
         expect(global[COVERAGE_VAR][pn 'b/bar.coffee'], "Should not instrument b/bar.coffee").to.not.exist
 
+    it "should exclude files based on globs with leading forward slash from project root when dynamically instrumenting code", ->
+
+        coffeeCoverage.register(
+            path: "relative"
+            basePath: path.resolve __dirname, '../testFixtures/testWithExcludes'
+            exclude: ["/b/*r.coffee"]
+            coverageVar: COVERAGE_VAR
+            log: log
+        )
+
+        require '../testFixtures/testWithExcludes/a/foo.coffee'
+        require '../testFixtures/testWithExcludes/b/bar.coffee'
+
+        expect(global[COVERAGE_VAR], "Code should have been instrumented").to.exist
+        expect(global[COVERAGE_VAR][pn 'a/foo.coffee'], "Should instrument a/foo.coffee").to.exist
+        expect(global[COVERAGE_VAR][pn 'b/bar.coffee'], "Should not instrument b/bar.coffee").to.not.exist
+
     it "should handle nested recursion correctly", ->
         # From https://github.com/benbria/coffee-coverage/pull/37
         instrumentor = new coffeeCoverage.CoverageInstrumentor({


### PR DESCRIPTION
It looks like when [**glob** package was swapped out for **minimatch**](https://github.com/benbria/coffee-coverage/commit/241e3c10c3c67b38886f407df4c794c1b44125c1), we accidentally lost [the ability to match globs with a leading forward slash](https://github.com/benbria/coffee-coverage/commit/d46300a20f9009dd5167577acd17e58aee81258f).

I'm first pushing the failing test to serve as example, then pushing the fix.  I can squash these if needed.

_Sidenote_: my master branch is a working version of coffee-coverage for Iced CoffeeScript.  It's almost perfect and backwards compatible, but will require upkeep so I haven't made a PR for it against the main package.  This package is really useful, thanks!
