### PR TITLE
Update dependencies; Walk Arrays of case statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,18 +44,18 @@
   "dependencies": {
     "argparse": "^1.0.2",
     "coffee-script": ">=1.6.2",
-    "lodash": "^3.7.0",
-    "minimatch": "^3.0.0",
+    "lodash": "^4.14.0",
+    "minimatch": "^3.0.2",
     "pkginfo": ">=0.2.3"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "coveralls": "^2.11.2",
-    "istanbul": "^0.3.13",
+    "istanbul": "^0.4.4",
     "mocha": "^2.1.0",
     "sinon": "^1.14.1",
     "benchmark": "^2.0.0",
-    "streamline": "^0.12.1"
+    "streamline": "0.12.1"
   },
   "scripts": {
     "prepublish": "npm run build && mocha",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,7 @@
     "Dmitry Petrov (https://github.com/can3p)",
     "Devon Govett (https://github.com/devongovett)"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/benbria/coffee-coverage/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "./lib/index",
   "repository": {
     "type": "git",

--- a/src/NodeWrapper.coffee
+++ b/src/NodeWrapper.coffee
@@ -161,6 +161,7 @@ module.exports = class NodeWrapper
         if @childName then answer += "#{@childName}[#{@childIndex}]:"
         answer += @type
         if @node.locationData? then answer += " (#{@node.locationData?.first_line + 1}:#{@node.locationData.first_column + 1})"
+        answer
 
 forNodeAndChildren = (node, fn) ->
     fn node

--- a/src/NodeWrapper.coffee
+++ b/src/NodeWrapper.coffee
@@ -38,6 +38,8 @@ module.exports = class NodeWrapper
         if @isStatement and @type is 'Value' and @parent.parent?.type is 'Class'
             @isStatement = false
 
+        @isSwitchCases = @childName is 'cases' and @type is 'Array'
+
 
     # Run `fn(node)` for each child of this node.  Child nodes will be automatically wrapped in a
     # `NodeWrapper`.

--- a/src/coffeeCoverage.coffee
+++ b/src/coffeeCoverage.coffee
@@ -334,6 +334,10 @@ exports._runInstrumentor = (instrumentor, fileName, source, options={}) ->
         # Call block-specific visitor function.
         visitor["visit#{nodeWrapper.type}"]?(nodeWrapper)
 
+        if nodeWrapper.isSwitchCases then for __, i in nodeWrapper.node
+            nodeWrapper.forEachChildOfType i, (child) ->
+                runVisitor(visitor, child)
+
         # Recurse into child nodes
         nodeWrapper.forEachChild (child) ->
             runVisitor(visitor, child)


### PR DESCRIPTION
Hello,

I updated the deps and noticed [a few tests were no longer passing](https://travis-ci.org/doublerebel/iced-coffee-coverage/jobs/147353527), since case statements now are wrapped as an array of nodes.  These `'Array'` nodes do not have location data, which caused `nodeWrapper.toString()` to return `undefined`.  These minor changes fix the issue and bring the package.json current.

Thanks!